### PR TITLE
add Cent0S support - enable Travis for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
   - distribution: ubuntu
     version: 16.04
-    init: /sbin/init
-    run_opts: ""
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
 services:
   - docker
@@ -39,11 +39,11 @@ script:
   - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
 
   # Test role idempotence.
-  # - >
-  #   sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml
-  #   | grep -q 'changed=0.*failed=0'
-  #   && (echo 'Idempotence test: pass' && exit 0)
-  #   || (echo 'Idempotence test: fail' && exit 1)
+  - >
+    sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)
 
   # Clean up
   - 'sudo docker stop "$(cat ${container_id})"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ env:
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
   - distribution: ubuntu
+    version: 12.04
+    init: /sbin/init
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: ubuntu
     version: 16.04
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,49 @@
 ---
-language: python
-python: "2.7"
+sudo: required
 
-# Use the new container infrastructure
-sudo: false
+env:
+  - distribution: centos
+    version: 7
+    init: /usr/lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: debian
+    version: jessie
+    init: /lib/systemd/systemd
+    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distribution: ubuntu
+    version: 16.04
+    init: /sbin/init
+    run_opts: ""
 
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+services:
+  - docker
 
-install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+before_install:
+  # Pull container
+  - 'sudo docker pull ${distribution}:${version}'
+  # Customize container
+  - 'sudo docker build --rm=true --file=tests/Dockerfile.${distribution}-${version} --tag=${distribution}-${version}:ansible tests'
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - container_id=$(mktemp)
+    # Run container in detached state
+  - 'sudo docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} ${distribution}-${version}:ansible "${init}" > "${container_id}"'
 
-notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  # Install dependencies.
+  - 'sudo docker exec "$(cat ${container_id})" ansible-galaxy install -r /etc/ansible/roles/role_under_test/tests/requirements.yml'
+
+  # Ansible syntax check.
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
+
+  # Test role.
+  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
+
+  # Test role idempotence.
+  - >
+    sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)
+
+  # Clean up
+  - 'sudo docker stop "$(cat ${container_id})"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ script:
 
   # Test role idempotence.
   - idempotence=$(mktemp)
-  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/$site | tee -a ${idempotence}
+  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/test.yml | tee -a ${idempotence}
   - >
     tail ${idempotence}
     | grep -q 'changed=0.*failed=0'

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,11 +39,11 @@ script:
   - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
 
   # Test role idempotence.
-  - >
-    sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml
-    | grep -q 'changed=0.*failed=0'
-    && (echo 'Idempotence test: pass' && exit 0)
-    || (echo 'Idempotence test: fail' && exit 1)
+  # - >
+  #   sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml
+  #   | grep -q 'changed=0.*failed=0'
+  #   && (echo 'Idempotence test: pass' && exit 0)
+  #   || (echo 'Idempotence test: fail' && exit 1)
 
   # Clean up
   - 'sudo docker stop "$(cat ${container_id})"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
-sudo: required
+services:
+  - docker
 
 env:
   - distribution: centos
@@ -15,28 +16,27 @@ env:
     init: /lib/systemd/systemd
     run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
 
-services:
-  - docker
+
 
 before_install:
   # Pull container
-  - 'sudo docker pull ${distribution}:${version}'
+  - 'docker pull ${distribution}:${version}'
   # Customize container
-  - 'sudo docker build --rm=true --file=tests/Dockerfile.${distribution}-${version} --tag=${distribution}-${version}:ansible tests'
+  - 'docker build --rm=true --file=tests/Dockerfile.${distribution}-${version} --tag=${distribution}-${version}:ansible tests'
 
 script:
   - container_id=$(mktemp)
     # Run container in detached state
-  - 'sudo docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} ${distribution}-${version}:ansible "${init}" > "${container_id}"'
+  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:ro ${run_opts} ${distribution}-${version}:ansible "${init}" > "${container_id}"'
 
   # Install dependencies.
-  - 'sudo docker exec "$(cat ${container_id})" ansible-galaxy install -r /etc/ansible/roles/role_under_test/tests/requirements.yml'
+  - 'docker exec "$(cat ${container_id})" ansible-galaxy install -r /etc/ansible/roles/role_under_test/tests/requirements.yml'
 
   # Ansible syntax check.
-  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
 
   # Test role.
-  - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
 
   # Test role idempotence.
   - idempotence=$(mktemp)
@@ -48,4 +48,4 @@ script:
     || (echo 'Idempotence test: fail' && exit 1)
 
   # Clean up
-  - 'sudo docker stop "$(cat ${container_id})"'
+  - 'docker stop "$(cat ${container_id})"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,13 +39,13 @@ script:
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
 
   # Test role idempotence.
-  - idempotence=$(mktemp)
-  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/test.yml | tee -a ${idempotence}
-  - >
-    tail ${idempotence}
-    | grep -q 'changed=0.*failed=0'
-    && (echo 'Idempotence test: pass' && exit 0)
-    || (echo 'Idempotence test: fail' && exit 1)
+  # - idempotence=$(mktemp)
+  # - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/test.yml | tee -a ${idempotence}
+  # - >
+  #   tail ${idempotence}
+  #   | grep -q 'changed=0.*failed=0'
+  #   && (echo 'Idempotence test: pass' && exit 0)
+  #   || (echo 'Idempotence test: fail' && exit 1)
 
   # Clean up
   - 'docker stop "$(cat ${container_id})"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,3 +53,6 @@ script:
 
   # Clean up
   - 'docker stop "$(cat ${container_id})"'
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,13 +43,13 @@ script:
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
 
   # Test role idempotence.
-  # - idempotence=$(mktemp)
-  # - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/test.yml | tee -a ${idempotence}
-  # - >
-  #   tail ${idempotence}
-  #   | grep -q 'changed=0.*failed=0'
-  #   && (echo 'Idempotence test: pass' && exit 0)
-  #   || (echo 'Idempotence test: fail' && exit 1)
+  - idempotence=$(mktemp)
+  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml | tee -a ${idempotence}
+  - >
+    tail ${idempotence}
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)
 
   # Clean up
   - 'docker stop "$(cat ${container_id})"'

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,10 @@ script:
   - 'sudo docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
 
   # Test role idempotence.
+  - idempotence=$(mktemp)
+  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/$site | tee -a ${idempotence}
   - >
-    sudo docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml
+    tail ${idempotence}
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)

--- a/README.md
+++ b/README.md
@@ -8,27 +8,15 @@ Install and update netdata.
 Requirements
 ------------
 
-* Systemd (optional)
+Ansible 2.2 or higher. Operating systems that use systemd as init system need the ansible systemd module.
 
 Role Variables
 --------------
 
 ```yaml
-    netdata_install_dir: /opt
-    netdata_systemd: True
-    netdata_deps:
-      - zlib1g-dev
-      - uuid-dev
-      - libmnl-dev
-      - gcc
-      - make
-      - git
-      - autoconf
-      - autoconf-archive
-      - autogen
-      - automake
-      - pkg-config
+    netdata_install_dir: /opt/netdata
 ```
+Netdata dependencies are loaded from within the vars file per operating system family (Debian or RedHat).
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 leanbit.netdata
 =========
 
-<<<<<<< HEAD
 [![Build Status](https://travis-ci.org/ymajik/ansible-role-netdata.svg?branch=master)](https://travis-ci.org/ymajik/ansible-role-netdata)
-=======
-[![Build Status](https://travis-ci.org/ymajik/ansible-role-netdata.svg?branch=feature-centos-compat)](https://travis-ci.org/ymajik/ansible-role-netdata)
->>>>>>> feature-centos-compat
 
 Install and update netdata.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 leanbit.netdata
 =========
 
+[![Build Status](https://travis-ci.org/ymajik/ansible-role-netdata.svg?branch=master)](https://travis-ci.org/ymajik/ansible-role-netdata)
+
 Install and update netdata.
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ymajik.netdata
 [![Build Status](https://travis-ci.org/ymajik/ansible-role-netdata.svg?branch=master)](https://travis-ci.org/ymajik/ansible-role-netdata)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-netdata-blue.svg?style=flat)](https://galaxy.ansible.com/ymajik/netdata)
 
-Install and update netdata.
+Ansible role to install and update [netdata](https://github.com/firehol/netdata).
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-leanbit.netdata
+ymajik.netdata
 =========
 
 [![Build Status](https://travis-ci.org/ymajik/ansible-role-netdata.svg?branch=master)](https://travis-ci.org/ymajik/ansible-role-netdata)
@@ -26,7 +26,7 @@ Including an example of how to use your role (for instance, with variables passe
 ```yaml
     - hosts: all
       roles:
-         - leanbit.netdata
+         - ymajik.netdata
 ```
 
 License
@@ -37,4 +37,4 @@ MIT
 Author Information
 ------------------
 
-Leanbit srl
+ymajik

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ ymajik.netdata
 =========
 
 [![Build Status](https://travis-ci.org/ymajik/ansible-role-netdata.svg?branch=master)](https://travis-ci.org/ymajik/ansible-role-netdata)
+[![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-netdata-blue.svg?style=flat)](https://galaxy.ansible.com/ymajik/netdata)
 
 Install and update netdata.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 leanbit.netdata
 =========
 
-Install and update netdata. 
+Install and update netdata.
 
 Requirements
 ------------
@@ -11,29 +11,33 @@ Requirements
 Role Variables
 --------------
 
+```yaml
     netdata_install_dir: /opt
     netdata_systemd: True
-    netdata_deps: 
-      - zlib1g-dev 
-      - uuid-dev 
-      - libmnl-dev 
-      - gcc 
-      - make 
-      - git 
-      - autoconf 
-      - autoconf-archive 
-      - autogen 
-      - automake 
+    netdata_deps:
+      - zlib1g-dev
+      - uuid-dev
+      - libmnl-dev
+      - gcc
+      - make
+      - git
+      - autoconf
+      - autoconf-archive
+      - autogen
+      - automake
       - pkg-config
+```
 
 Example Playbook
 ----------------
 
 Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
 
+```yaml
     - hosts: all
       roles:
          - leanbit.netdata
+```
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Role Variables
     netdata_version: v1.5.0
 ```
 Netdata dependencies are loaded from within the vars file per operating system family (Debian or RedHat).
+If you want to install the latest netdata release, specify **HEAD** as netdata_version.
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ymajik.netdata
 [![Build Status](https://travis-ci.org/ymajik/ansible-role-netdata.svg?branch=master)](https://travis-ci.org/ymajik/ansible-role-netdata)
 [![Ansible Galaxy](https://img.shields.io/badge/ansible--galaxy-netdata-blue.svg?style=flat)](https://galaxy.ansible.com/ymajik/netdata)
 
-Ansible role to install and update [netdata](https://github.com/firehol/netdata).
+Ansible role to install and update [netdata](https://github.com/firehol/netdata) on Debian, Ubuntu and CentOS.
 
 Requirements
 ------------

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 leanbit.netdata
 =========
 
+[![Build Status](https://travis-ci.org/ymajik/ansible-role-netdata.svg?branch=feature-centos-compat)](https://travis-ci.org/ymajik/ansible-role-netdata)
+
 Install and update netdata.
 
 Requirements

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Role Variables
 
 ```yaml
     netdata_install_dir: /opt/netdata
+    netdata_version: v1.5.0
 ```
 Netdata dependencies are loaded from within the vars file per operating system family (Debian or RedHat).
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for leanbit.netdata
-netdata_download_dir: /tmp/netdata
+netdata_install_dir: /opt/netdata

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 # defaults file for leanbit.netdata
 netdata_install_dir: /opt
-netdata_systemd: True

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for leanbit.netdata
 netdata_install_dir: /opt/netdata
-netdata_version: v1.5.0
+netdata_version: HEAD

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for leanbit.netdata
 netdata_install_dir: /opt/netdata
+netdata_version: v1.5.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for leanbit.netdata
-netdata_install_dir: /opt
+netdata_download_dir: /tmp/netdata

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,15 +2,3 @@
 # defaults file for leanbit.netdata
 netdata_install_dir: /opt
 netdata_systemd: True
-netdata_deps: 
-  - zlib1g-dev 
-  - uuid-dev 
-  - libmnl-dev 
-  - gcc 
-  - make 
-  - git 
-  - autoconf 
-  - autoconf-archive 
-  - autogen 
-  - automake 
-  - pkg-config

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,12 +6,17 @@
     state: stopped
   when: netdata_present.stat.exists == True
 
-- name: start and enable service
-  service:
+- name: start and enable systemd
+  systemd:
     name: netdata
     state: started
     enabled: yes
     daemon_reload: yes
   become: true
-  tags:
-    - netdata
+
+- name: start and enable service
+  service:
+    name: netdata
+    state: started
+    enabled: yes
+  become: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,6 @@
 ---
 # handlers file for leanbit.netdata
+- name: stop service
+  service:
+    name: netdata
+    state: stopped

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,6 +4,7 @@
   service:
     name: netdata
     state: stopped
+  when: netdata_present.stat.exists == True
 
 - name: start and enable service
   service:
@@ -11,7 +12,6 @@
     state: started
     enabled: yes
     daemon_reload: yes
-  when: clone_or_pull.changed == True
   become: true
   tags:
     - netdata

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,3 +4,14 @@
   service:
     name: netdata
     state: stopped
+
+- name: start and enable service
+  service:
+    name: netdata
+    state: started
+    enabled: yes
+    daemon_reload: yes
+  when: clone_or_pull.changed == True
+  become: true
+  tags:
+    - netdata

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: ymajik
-  description: Install and Update netdata
+  description: Install and update netdata
   company:
 
   # If the issue tracker for your role is not on github, uncomment the

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,7 +17,7 @@ galaxy_info:
   # - CC-BY
   license: MIT
 
-  min_ansible_version: 2.0
+  min_ansible_version: 2.2
 
   # Optionally specify the branch Galaxy will use when accessing the GitHub
   # repo for this role. During role install, if no tags are available,
@@ -33,12 +33,12 @@ galaxy_info:
   # platform on this list, let us know and we'll get it added!
   #
   platforms:
-  #- name: EL
-  #  versions:
+    - name: EL
+      versions:
   #  - all
   #  - 5
   #  - 6
-  #  - 7
+        - 7
   #- name: GenericUNIX
   #  versions:
   #  - all
@@ -169,18 +169,18 @@ galaxy_info:
   #  versions:
   #  - all
   #  - any
-  #- name: Debian
-  #  versions:
+    - name: Debian
+      versions:
   #  - all
   #  - etch
-  #  - jessie
+      - jessie
   #  - lenny
   #  - sid
   #  - squeeze
   #  - stretch
   #  - wheezy
 
-  galaxy_tags: 
+  galaxy_tags:
     - monitoring
     # List tags for your role here, one per line. A tag is
     # a keyword that describes and categorizes the role.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,31 +1,16 @@
 ---
 galaxy_info:
-  author: Michele Minazzato
+  author: ymajik
   description: Install and Update netdata
-  company: Leanbit srl
+  company:
 
   # If the issue tracker for your role is not on github, uncomment the
   # next line and provide a value
   # issue_tracker_url: http://example.com/issue/tracker
 
-  # Some suggested licenses:
-  # - BSD (default)
-  # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
   license: MIT
 
   min_ansible_version: 2.2
-
-  # Optionally specify the branch Galaxy will use when accessing the GitHub
-  # repo for this role. During role install, if no tags are available,
-  # Galaxy will use this branch. During import Galaxy will access files on
-  # this branch. If travis integration is cofigured, only notification for this
-  # branch will be accepted. Otherwise, in all cases, the repo's default branch
-  # (usually master) will be used.
-  #github_branch:
 
   #
   # Below are all platforms currently available. Just uncomment
@@ -35,22 +20,7 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-  #  - all
-  #  - 5
-  #  - 6
         - 7
-  #- name: GenericUNIX
-  #  versions:
-  #  - all
-  #  - any
-  #- name: OpenBSD
-  #  versions:
-  #  - all
-  #  - 5.6
-  #  - 5.7
-  #  - 5.8
-  #  - 5.9
-  #  - 6.0
   #- name: Fedora
   #  versions:
   #  - all
@@ -62,110 +32,23 @@ galaxy_info:
   #  - 21
   #  - 22
   #  - 23
-  #- name: opensuse
-  #  versions:
-  #  - all
-  #  - 12.1
-  #  - 12.2
-  #  - 12.3
-  #  - 13.1
-  #  - 13.2
-  #- name: MacOSX
-  #  versions:
-  #  - all
-  #  - 10.10
-  #  - 10.11
-  #  - 10.12
-  #  - 10.7
-  #  - 10.8
-  #  - 10.9
-  #- name: IOS
-  #  versions:
-  #  - all
-  #  - any
-  #- name: Solaris
-  #  versions:
-  #  - all
-  #  - 10
-  #  - 11.0
-  #  - 11.1
-  #  - 11.2
-  #  - 11.3
-  #- name: SmartOS
-  #  versions:
-  #  - all
-  #  - any
-  #- name: eos
-  #  versions:
-  #  - all
-  #  - Any
-  #- name: Windows
-  #  versions:
-  #  - all
-  #  - 2012R2
-  #- name: Amazon
-  #  versions:
-  #  - all
-  #  - 2013.03
-  #  - 2013.09
-  #- name: GenericBSD
-  #  versions:
-  #  - all
-  #  - any
-  #- name: Junos
-  #  versions:
-  #  - all
-  #  - any
-  #- name: FreeBSD
-  #  versions:
-  #  - all
-  #  - 10.0
-  #  - 10.1
-  #  - 10.2
-  #  - 10.3
-  #  - 8.0
-  #  - 8.1
-  #  - 8.2
-  #  - 8.3
-  #  - 8.4
-  #  - 9.0
-  #  - 9.1
-  #  - 9.1
-  #  - 9.2
-  #  - 9.3
     - name: Ubuntu
       versions:
-      - all
+  #  - all
   #  - lucid
   #  - maverick
   #  - natty
   #  - oneiric
-  #  - precise
+      - precise
   #  - quantal
   #  - raring
   #  - saucy
-  #  - trusty
+      - trusty
   #  - utopic
   #  - vivid
   #  - wily
-  #  - xenial
-  #- name: SLES
-  #  versions:
-  #  - all
-  #  - 10SP3
-  #  - 10SP4
-  #  - 11
-  #  - 11SP1
-  #  - 11SP2
-  #  - 11SP3
-  #  - 11SP4
-  #  - 12
-  #  - 12SP1
+      - xenial
   #- name: GenericLinux
-  #  versions:
-  #  - all
-  #  - any
-  #- name: NXOS
   #  versions:
   #  - all
   #  - any
@@ -182,6 +65,8 @@ galaxy_info:
 
   galaxy_tags:
     - monitoring
+    - netdata
+    - performance
     # List tags for your role here, one per line. A tag is
     # a keyword that describes and categorizes the role.
     # Users find roles by searching for tags. Be sure to

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,7 @@
       repo: https://github.com/firehol/netdata.git
       dest: "{{ netdata_install_dir }}"
       depth: 1
+      version: "{{ netdata_version }}"
     register: clone_or_pull
 
   - debug: var=clone_or_pull

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,10 +41,10 @@
 
   - name: copy service file
     command: cp {{ netdata_install_dir }}/system/netdata.service /etc/systemd/system/netdata.service
-    when: ansible_service_mgr == "systemd"
+    when: clone_or_pull.changed == True and ansible_service_mgr == "systemd"
     notify: start and enable systemd
 
   - name: copy service file
     command: cp {{ netdata_install_dir }}/system/netdata-lsb /etc/init.d/netdata
-    when: ansible_service_mgr == "init"
+    when: clone_or_pull.changed == True and ansible_service_mgr == "init"
     notify: start and enable service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,6 @@
     git:
       repo: https://github.com/firehol/netdata.git
       dest: "{{ netdata_install_dir }}"
-      depth: 1
       version: "{{ netdata_version }}"
     register: clone_or_pull
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,12 +45,12 @@
 
   - name: copy service file
     command: cp "{{ netdata_download_dir }}/system/netdata.service /etc/systemd/system/"
-    when: ansible_service_mgr == systemd
+    when: ansible_service_mgr == "systemd"
     notify: start and enable service
 
   - name: copy service file
     command: cp /tmp/netdata/system/netdata-lsb /etc/init.d/netdata
-    when: ansible_service_mgr == init
+    when: ansible_service_mgr == "init"
     notify: start and enable service
 
   - name: start and enable service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
   - meta: flush_handlers
 
   - name: copy service file
-    command: cp "{{ netdata_download_dir }}/system/netdata.service /etc/systemd/system/netdata.service"
+    command: cp {{ netdata_download_dir }}/system/netdata.service /etc/systemd/system/netdata.service
     when: ansible_service_mgr == "systemd"
     notify: start and enable service
 
@@ -52,13 +52,3 @@
     command: cp /tmp/netdata/system/netdata-lsb /etc/init.d/netdata
     when: ansible_service_mgr == "init"
     notify: start and enable service
-
-  - name: start and enable service
-    service:
-      name: netdata
-      state: started
-      enabled: yes
-    when: clone_or_pull.changed == True
-    become: true
-    tags:
-      - netdata

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,16 +40,32 @@
     become: yes
     tags:
       - netdata
+    notify: stop service
 
-  - name: NETDATA | Configure Systemd
-    command: "{{ item }}"
-    with_items:
-      - killall netdata
-      - cp /tmp/netdata/system/netdata.service /etc/systemd/system/
-      - systemctl daemon-reload
-      - systemctl enable netdata
-      - service netdata restart
-    when: clone_or_pull.changed == True and netdata_systemd == True
+- meta: flush_handlers
+
+  - name: stop service
+    service:
+      name: netdata
+      state: stopped
+    notify: copy service file
+
+  - name: copy service file
+    command: cp /tmp/netdata/system/netdata.service /etc/systemd/system/
+    when: ansible_service_mgr == systemd
+    notify: start and enable service
+
+  - name: copy service file
+    command: cp /tmp/netdata/system/netdata-lsb /etc/init.d/netdata
+    when: ansible_service_mgr == init
+    notify: start and enable service
+
+  - name: start and enable service
+    service:
+      name: netdata
+      state: started
+      enabled: yes
+    when: clone_or_pull.changed == True
     become: true
     tags:
       - netdata

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,8 +18,6 @@
     with_items: "{{ netdata_deps }}"
     when: netdata_present.stat.exists == False
     become: yes
-    tags:
-     - netdata
 
   - name: NETDATA | Clone or Pull for Install or Update
     git:
@@ -27,8 +25,7 @@
       dest: "{{ netdata_install_dir }}"
       depth: 1
     register: clone_or_pull
-    tags:
-      - netdata
+
   - debug: var=clone_or_pull
 
   - name: NETDATA | Build and install
@@ -37,8 +34,7 @@
       chdir: "{{ netdata_install_dir }}"
     when: clone_or_pull.changed == True
     become: yes
-    tags:
-      - netdata
+
     notify: stop service
 
   - meta: flush_handlers
@@ -46,7 +42,7 @@
   - name: copy service file
     command: cp {{ netdata_install_dir }}/system/netdata.service /etc/systemd/system/netdata.service
     when: ansible_service_mgr == "systemd"
-    notify: start and enable service
+    notify: start and enable systemd
 
   - name: copy service file
     command: cp {{ netdata_install_dir }}/system/netdata-lsb /etc/init.d/netdata

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
       - netdata
     notify: stop service
 
-- meta: flush_handlers
+  - meta: flush_handlers
 
   - name: stop service
     service:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
+  - name: Include OS-specific variables.
+    include_vars: "{{ ansible_os_family }}.yml"
+
   - name: NETDATA | Check if present
-    stat: path={{netdata_install_dir}}/netdata
+    stat:
+      path: "{{ netdata_install_dir }}/netdata"
     register: netdata_present
   - debug: msg="netdata not installed"
     when: netdata_present.stat.exists == False
@@ -8,22 +12,28 @@
     when: netdata_present.stat.exists == True
 
   - name: NETDATA | Install package dependencies
-    apt: pkg='{{item}}' state=present
-    with_items: "{{netdata_deps}}"
-    when: netdata_present.stat.exists == False 
+    package:
+      name: "{{ item }}"
+      state: present
+    with_items: "{{ netdata_deps }}"
+    when: netdata_present.stat.exists == False
     become: yes
     tags:
-     - netdata 
+     - netdata
 
   - name: NETDATA | Clone or Pull for Install or Update
-    git: repo=https://github.com/firehol/netdata.git dest={{netdata_install_dir}}/netdata depth="1" dest="/tmp/netdata"
+    git:
+      repo: https://github.com/firehol/netdata.git
+      dest: "{{ netdata_install_dir}}/netdata"
+      depth: 1
+      dest: /tmp/netdata
     register: clone_or_pull
     tags:
       - netdata
   - debug: var=clone_or_pull
 
   - name: NETDATA | Build and install
-    shell: "./netdata-installer.sh --install {{netdata_install_dir}} --dont-wait"
+    shell: "./netdata-installer.sh --install {{ netdata_install_dir }} --dont-wait"
     args:
       chdir: /tmp/netdata
     when: clone_or_pull.changed == True
@@ -32,7 +42,7 @@
       - netdata
 
   - name: NETDATA | Configure Systemd
-    command: "{{item}}"
+    command: "{{ item }}"
     with_items:
       - killall netdata
       - cp /tmp/netdata/system/netdata.service /etc/systemd/system/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -44,7 +44,7 @@
   - meta: flush_handlers
 
   - name: copy service file
-    command: cp "{{ netdata_download_dir }}/system/netdata.service /etc/systemd/system/"
+    command: cp "{{ netdata_download_dir }}/system/netdata.service /etc/systemd/system/netdata.service"
     when: ansible_service_mgr == "systemd"
     notify: start and enable service
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
   - name: NETDATA | Clone or Pull for Install or Update
     git:
       repo: https://github.com/firehol/netdata.git
-      dest: "{{ netdata_download_dir }}"
+      dest: "{{ netdata_install_dir }}"
       depth: 1
     register: clone_or_pull
     tags:
@@ -32,9 +32,9 @@
   - debug: var=clone_or_pull
 
   - name: NETDATA | Build and install
-    shell: "./netdata-installer.sh --install {{ netdata_download_dir }} --dont-wait"
+    shell: "./netdata-installer.sh --install {{ netdata_install_dir }} --dont-wait"
     args:
-      chdir: "{{ netdata_download_dir }}"
+      chdir: "{{ netdata_install_dir }}"
     when: clone_or_pull.changed == True
     become: yes
     tags:
@@ -44,11 +44,11 @@
   - meta: flush_handlers
 
   - name: copy service file
-    command: cp {{ netdata_download_dir }}/system/netdata.service /etc/systemd/system/netdata.service
+    command: cp {{ netdata_install_dir }}/system/netdata.service /etc/systemd/system/netdata.service
     when: ansible_service_mgr == "systemd"
     notify: start and enable service
 
   - name: copy service file
-    command: cp /tmp/netdata/system/netdata-lsb /etc/init.d/netdata
+    command: cp {{ netdata_install_dir }}/system/netdata-lsb /etc/init.d/netdata
     when: ansible_service_mgr == "init"
     notify: start and enable service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,7 +4,7 @@
 
   - name: NETDATA | Check if present
     stat:
-      path: "{{ netdata_install_dir }}/netdata"
+      path: "{{ netdata_binary }}"
     register: netdata_present
   - debug: msg="netdata not installed"
     when: netdata_present.stat.exists == False
@@ -24,18 +24,17 @@
   - name: NETDATA | Clone or Pull for Install or Update
     git:
       repo: https://github.com/firehol/netdata.git
-      dest: "{{ netdata_install_dir}}/netdata"
+      dest: "{{ netdata_download_dir }}"
       depth: 1
-      dest: /tmp/netdata
     register: clone_or_pull
     tags:
       - netdata
   - debug: var=clone_or_pull
 
   - name: NETDATA | Build and install
-    shell: "./netdata-installer.sh --install {{ netdata_install_dir }} --dont-wait"
+    shell: "./netdata-installer.sh --install {{ netdata_download_dir }} --dont-wait"
     args:
-      chdir: /tmp/netdata
+      chdir: "{{ netdata_download_dir }}"
     when: clone_or_pull.changed == True
     become: yes
     tags:
@@ -44,14 +43,8 @@
 
   - meta: flush_handlers
 
-  - name: stop service
-    service:
-      name: netdata
-      state: stopped
-    notify: copy service file
-
   - name: copy service file
-    command: cp /tmp/netdata/system/netdata.service /etc/systemd/system/
+    command: cp "{{ netdata_download_dir }}/system/netdata.service /etc/systemd/system/"
     when: ansible_service_mgr == systemd
     notify: start and enable service
 

--- a/tests/Dockerfile.centos-7
+++ b/tests/Dockerfile.centos-7
@@ -1,0 +1,27 @@
+FROM centos:7
+
+# Install systemd -- See https://hub.docker.com/_/centos/
+RUN yum -y swap -- remove fakesystemd -- install systemd systemd-libs
+RUN yum -y update; yum clean all; \
+(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*; \
+rm -f /etc/systemd/system/*.wants/*; \
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*; \
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+# Install Ansible
+RUN yum -y install epel-release
+RUN yum -y install git ansible sudo
+RUN yum clean all
+
+# Disable requiretty
+RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
+
+# Install Ansible inventory file
+RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
+
+VOLUME ["/sys/fs/cgroup"]
+CMD ["/usr/sbin/init"]

--- a/tests/Dockerfile.debian-jessie
+++ b/tests/Dockerfile.debian-jessie
@@ -1,0 +1,14 @@
+FROM debian:jessie
+RUN apt-get update -y
+
+# Install Ansible
+RUN apt-get install --no-install-recommends -y -q build-essential ca-certificates python-pip python-dev python-yaml libffi-dev libssl-dev libxml2-dev libxslt1-dev zlib1g-dev git
+RUN apt-get -y --purge remove python-cffi
+RUN pip install --upgrade cffi
+RUN pip install --upgrade pyyaml jinja2 pycrypto
+RUN pip install ansible
+
+# Install Ansible inventory file
+RUN mkdir -pv /etc/ansible
+RUN touch /etc/ansible/hosts
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/Dockerfile.ubuntu-12.04
+++ b/tests/Dockerfile.ubuntu-12.04
@@ -1,0 +1,11 @@
+FROM ubuntu:12.04
+RUN apt-get update
+
+# Install Ansible
+RUN apt-get install -y software-properties-common git python-software-properties
+RUN apt-add-repository -y ppa:ansible/ansible
+RUN apt-get update
+RUN apt-get install -y ansible
+
+# Install Ansible inventory file
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/Dockerfile.ubuntu-16.04
+++ b/tests/Dockerfile.ubuntu-16.04
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+RUN apt-get update
+
+# Install Ansible
+RUN apt-get install -y software-properties-common git
+RUN apt-add-repository -y ppa:ansible/ansible
+RUN apt-get update
+RUN apt-get install -y ansible
+
+# Install Ansible inventory file
+RUN echo "[local]\nlocalhost ansible_connection=local" > /etc/ansible/hosts

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,10 @@
 ---
-- hosts: localhost
-  remote_user: root
+- hosts: all
+
+  pre_tasks:
+    - name: Update apt cache.
+      apt: update_cache=yes
+      when: ansible_os_family == 'Debian'
+
   roles:
-    - ansible-netdata
+    - role_under_test

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,10 +1,5 @@
 ---
 - hosts: all
 
-  pre_tasks:
-    - name: Update apt cache.
-      apt: update_cache=yes
-      when: ansible_os_family == 'Debian'
-
   roles:
     - role_under_test

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,4 +1,5 @@
 ---
+netdata_binary: /usr/sbin/netdata
 netdata_deps:
   - zlib1g-dev
   - uuid-dev

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,13 @@
+---
+netdata_deps:
+  - zlib1g-dev
+  - uuid-dev
+  - libmnl-dev
+  - gcc
+  - make
+  - git
+  - autoconf
+  - autoconf-archive
+  - autogen
+  - automake
+  - pkg-config

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,18 @@
+---
+netdata_deps:
+  - autoconf
+  - automake
+  - curl
+  - gcc
+  - git
+  - libmnl-devel
+  - libuuid-devel
+  - lm_sensors
+  - make
+  - MySQL-python
+  - nc
+  - pkgconfig
+  - python
+  - python-psycopg2
+  - PyYAML
+  - zlib-devel

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,5 @@
 ---
+netdata_binary: /sbin/netdata
 netdata_deps:
   - autoconf
   - automake


### PR DESCRIPTION
Hi, I've forked and rewritten the role a bit, to support CentOS and enable automate testing for the different operating systems.
Shell commands for stopping and starting netdata were replaced with the appropriate service and systemd ansible modules. Let me know what you think of the changes,
kind regards,
Y